### PR TITLE
fix: typo east => west

### DIFF
--- a/levels/javascript/objectives/js_west_bridge/objective.json
+++ b/levels/javascript/objectives/js_west_bridge/objective.json
@@ -1,6 +1,6 @@
 {
   "title": "JavaScript Lab: If Alive Then Bridge",
-  "description": "Extend the east bridge by learning to use an <strong>else statement</strong> in your conditional logic.",
+  "description": "Extend the west bridge by learning to use an <strong>else statement</strong> in your conditional logic.",
   "validation_fields": [
     {
       "name": "prompt",


### PR DESCRIPTION
Fixed a typo in the objective file. The challenge is to extend the west bridge, and not the east bridge.